### PR TITLE
Doc patch for optional HTML meta attribute

### DIFF
--- a/lib/Plack/Middleware/CSRFBlock.pm
+++ b/lib/Plack/Middleware/CSRFBlock.pm
@@ -189,10 +189,9 @@ to your application, in most cases. Here is the strategy:
 =item output filter
 
 When the application response content-type is "text/html" or
-"application/xhtml+xml", this inserts hidden input tag that contains token
-string into C<form>s in the response body.  It can also adds an optional meta
-tag (by setting C<add_meta> to true) with the default name "csrftoken".
-For example, the application response body is:
+"application/xhtml+xml", this inserts a hidden input tag that contains a token
+string into C<form>s in the response body. For example, when the application
+response body is:
 
   <html>
     <head>
@@ -204,10 +203,10 @@ For example, the application response body is:
       </form>
   </html>
 
-this becomes:
+This becomes:
 
   <html>
-    <head><meta name="csrftoken" content="0f15ba869f1c0d77"/>
+    <head>
         <title>input form</title>
     </head>
     <body>
@@ -217,6 +216,21 @@ this becomes:
   </html>
 
 This affects C<form> tags with C<method="post">, case insensitive.
+
+It is possible to add an optional meta tag by setting C<meta_tag> to a defined
+value. The 'name' attribute of the HTML tag will be set to the value of
+C<meta_tag>. For the previous example, when C<meta_tag> is set to
+'csrf_token', the output will be:
+
+  <html>
+    <head><meta name="csrf_token" content="0f15ba869f1c0d77"/>
+        <title>input form</title>
+    </head>
+    <body>
+      <form action="/api" method="post"><input type="hidden" name="SEC" value="0f15ba869f1c0d77" />
+        <input type="text" name="email" /><input type="submit" />
+      </form>
+  </html>
 
 =item input check
 


### PR DESCRIPTION
Hi,

This is a small doc patch to reflect how we've observed the module working ('meta_tag' as the enabling attribute rather than 'add_meta'). Obviously if the intention is to use add_meta with the default then this is redundant.

Cheers
Matt 
